### PR TITLE
update documentation because now make is used instead of build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ CLI Reddit client written in C. Oh, crossplatform too!
 
 How to build
 ============
-You'll need libncurses and libcurl to build. Then just run ./build.sh really.
+You'll need libncurses and libcurl to build. Then just run 'make' really.


### PR DESCRIPTION
I saw that you now use Make instead of your own (?) build.sh-Shellscript and thought it would be nice to have it updated in the README.

PS: My first pull request ever, yay! Hope this small change goes through.
