### PR TITLE
Make 'h' in thread leave thread

### DIFF
--- a/main.c
+++ b/main.c
@@ -110,7 +110,7 @@ void showThread(Post *posts, int selected, int displayCount) {
     int c;
     while(c =wgetch(stdscr))
     {
-        if(c == 'q')
+        if (c == 'q' || c ==  'h')
             break;
         switch(c)
         {
@@ -122,7 +122,6 @@ void showThread(Post *posts, int selected, int displayCount) {
                     refresh();
                 }
                 break;
-
             case 'k': case KEY_UP:
                 if (selectedComment != 0){
                     selectedComment--;


### PR DESCRIPTION
'h', the opposite of 'l', seems like the sane key to use to leave the
comment thread.
