### PR TITLE
Link against libncursesw instead of libncurses

### DIFF
--- a/src/creddit.mk
+++ b/src/creddit.mk
@@ -1,6 +1,6 @@
 
 CREDDIT_CFLAGS:=$(PROJCFLAGS)
-CREDDIT_LDFLAGS:=-lncurses `curl-config --cflags` `curl-config --libs` -L$(BUILD_DIR) -lreddit
+CREDDIT_LDFLAGS:=-lncursesw `curl-config --cflags` `curl-config --libs` -L$(BUILD_DIR) -lreddit
 
 EXECUTABLE_NAME:=creddit
 CREDDIT_DIR_CMP:=$(BUILD_DIR)/src


### PR DESCRIPTION
A nice one-character change ;D

This simply fixes the error experienced by Omajid [here](https://github.com/Cotix/cReddit/commit/4f824b5e2e700da7f36d3144b0dc3a1ce7191149#commitcomment-4259053). When the project switched to using wchar_t with ncurses, it needed to start linking against libncursesw, the wide-character version of ncurses. Some OS's (Mine: ArchLinux), did this linking automatically for whatever reason, so I didn't experience any errors. On other OS's though (Ex. Fedora), the linking doesn't happen and linker errors appear. Linking against libncursesw fixes the issue.
