### PR TITLE
creddit: Add code to Makefile setup to check the running system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ endif
 
 all: real-all
 
+include ./common.mk
+
 # Set initial values for 'targets'
 CLEAN_TARGETS:=
 COMPILE_TARGETS:=

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,10 @@
+# Makefile for registering info about the system we're compiling on.
+
+UNAME=$(shell uname -r)
+ifeq ('Darwin','$(UNAME)')
+	F_MACOSX=yes
+endif
+ifeq ('Linux','$(UNAME)')
+	F_LINUX=yes
+endif
+

--- a/src/creddit.mk
+++ b/src/creddit.mk
@@ -1,6 +1,12 @@
 
 CREDDIT_CFLAGS:=$(PROJCFLAGS)
-CREDDIT_LDFLAGS:=$(PROJLDFILES) -lncursesw -L$(BUILD_DIR) -lreddit
+CREDDIT_LDFLAGS:=$(PROJLDFILES) -L$(BUILD_DIR) -lreddit
+ifdef F_MACOSX
+	CREDDIT_LDFLAGS+=-lncurses
+else
+	CREDDIT_LDFLAGS+=-lncursesw
+endif
+
 ifdef STATIC
     CREDDIT_LDFLAGS+=`curl-config --cflags` `curl-config --libs`
 endif


### PR DESCRIPTION
This commit adds the file common.mk, which runs various commands on the
target system and sets macros that can be used in other Makefiles to
compile with different settings on different machines.

Currently, the only setting is 'umake -r', which checks the running
Kernel (Currently just checked for 'Linux' or 'Drawin'). In creddit.mk,
this is used to decide which ncurses library to link against.

This fix also implements the fix for compiling on MacOSX.
