### PR TITLE
creddit: libreddit: Fix various spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ directory.
 
 If you would like to compile libreddit on its own as a shared library, you can
 run ``` make libreddit ```. The resulting shared library will be
-./build/libreddit.so.  You can also install the library sepratly via ``` make
+./build/libreddit.so.  You can also install the library separately via ``` make
 libreddit_install ```.  To use the library, include "reddit.h" and link against
 libreddit.so.
 

--- a/include/reddit.h
+++ b/include/reddit.h
@@ -18,27 +18,27 @@ typedef enum RedditErrno {
      * It's use should be avoided if possible */
     REDDIT_ERROR,
 
-    /* Issue with the text recieved from reddit
+    /* Issue with the text received from reddit
      * Probably a parsing issue with that JSON */
     REDDIT_ERROR_RESPONSE,
 
     /* Unable to connect to reddit.com */
     REDDIT_ERROR_NOTCON,
 
-    /* Specefic error for logging on
+    /* Specific error for logging on
      * Indicates an issue with password or username */
     REDDIT_ERROR_USER
 
 } RedditErrno;
 
 /*
- * This structure holds data on a cookie recieved from Reddit.  In general,
+ * This structure holds data on a cookie received from Reddit.  In general,
  * these are allocated and stored automatically in the current global state, so
- * allocating them directly isn't nessisary. The only real use it has
+ * allocating them directly isn't necessary. The only real use it has
  * externally is reading the name and data from a cookie in the current state
  * so you can save it for later use. Cookies should be added to the current
  * global state by a separate API call, and removed by another separate API
- * call, so allocating them directly shouldn't be nessisary
+ * call, so allocating them directly shouldn't be necessary
  */
 typedef struct RedditCookieLink {
     struct RedditCookieLink *next;
@@ -48,7 +48,7 @@ typedef struct RedditCookieLink {
 
 
 /*
- * This structure repreents the current state of the library, or more specefically
+ * This structure represents the current state of the library, or more specifically
  * of the Reddit Session.
  *
  * Currently, all it does is contain a linked-list of cookies being used in the session
@@ -96,14 +96,14 @@ typedef struct RedditUser {
 
 
 /*
- * A superset of 'reddit_user', coresponds to a user that is or is going to
+ * A superset of 'reddit_user', corresponds to a user that is or is going to
  * log-in. Includes a full RedditUser as well as extra info related to
  * logged-in state
  */
 typedef struct RedditUserLogged {
     RedditUserState userState;
     bool stayLoggedOn; /* If this is set when logged-in, the API will request
-                        * a persistant cookie, which you can then save and use
+                        * a persistent cookie, which you can then save and use
                         * again later-on */
 
     RedditUser *userInfo;
@@ -184,7 +184,7 @@ typedef struct RedditLinkList {
 /*
  * Similar to RedditUser in structure, but it's use is a bit more complex:
  *
- * Reddit has two ways of informing about comments. Specefically, in any
+ * Reddit has two ways of informing about comments. Specifically, in any
  * comment listing from Reddit, you'll have directly displayed comments and
  * hidden comments.  'hidden comments' are simply the 'click to see more
  * replies' on the webpage which aren't displayed by default unless you click
@@ -330,7 +330,7 @@ extern RedditErrno redditGetCommentChildren (RedditCommentList *list, RedditComm
 extern char *redditCopyString (const char *string);
 
 /* Global init and clean-up functions. These should be called at the start and
- * end of a program, respectivly. */
+ * end of a program, respectively. */
 extern void redditGlobalInit();
 extern void redditGlobalCleanup();
 

--- a/libreddit/comment.c
+++ b/libreddit/comment.c
@@ -21,7 +21,7 @@ EXPORT_SYMBOL RedditComment *redditCommentNew ()
 }
 
 /*
- * Recurrisivly free's all replys on a RedditComment
+ * Recursively free's all replys on a RedditComment
  */
 EXPORT_SYMBOL void redditCommentFreeReplies (RedditComment *comment)
 {
@@ -122,7 +122,7 @@ DEF_TOKEN_CALLBACK(getCommentRepliesMore)
 }
 
 /*
- * This callback is sort of a 'dispatch' which simply deligates what to do to the relevant functions
+ * This callback is sort of a 'dispatch' which simply delegates what to do to the relevant functions
  *
  * In the event of a 't3' datatype, we have a RedditLink and call redditGetLink to parse it
  * A 't1' is a comment, so we use redditGetComment, and then redditCommentAddReply

--- a/libreddit/link.c
+++ b/libreddit/link.c
@@ -18,7 +18,7 @@ EXPORT_SYMBOL RedditLink *redditLinkNew ()
 {
     RedditLink *link = rmalloc(sizeof(RedditLink));
 
-    /* Just initalize everything as NULL or zero */
+    /* Just initialize everything as NULL or zero */
     memset(link, 0, sizeof(RedditLink));
 
     return link;

--- a/libreddit/token.c
+++ b/libreddit/token.c
@@ -132,7 +132,7 @@ size_t writeToParser(void *contents, size_t size, size_t nmemb, void *userp)
  * Returns either 'True' or 'False' in string form of a bool value
  *
  * The return value is always the exact same pointer of 'string'
- * Note -- 'string' should be already allocated to atleast a length of 6
+ * Note -- 'string' should be already allocated to at least a length of 6
  */
 char *trueFalseString(char *string, bool tf)
 {
@@ -226,7 +226,7 @@ int performIdentAction(TokenParser *p, TokenIdent *identifiers, int i, va_list a
 
 /*
  * This function parses a json object, looking for tokens and calling the proper
- * function callback if nessisary
+ * function callback if necessary
  *
  * When called, this function will assume p->tokens[p->currentToken] points to
  * the start of an object, and will return if this is not the case

--- a/libreddit/token.h
+++ b/libreddit/token.h
@@ -44,11 +44,11 @@ typedef enum TokenParserResult {
  * Json notation works on a system of 'key' and 'value' pairs. Ex:
  *   { "Key": "Value", "Key2": "Value2", ...
  *
- * When getting output from Reddit, key's stay largly the same every time
+ * When getting output from Reddit, key's stay largely the same every time
  * something is called. The value is then the data you're interested in. This
- * structure handles detailing how to handle a paticular key value, whether it
+ * structure handles detailing how to handle a particular key value, whether it
  * should be handled by assigning the value to a pointer, or call a function
- * callback to handle it when that specefic key is found.
+ * callback to handle it when that specific key is found.
  */
 typedef struct TokenIdent {
 
@@ -80,7 +80,7 @@ typedef struct TokenIdent {
      * unsigned int, and |= with bitMask. If 'false', it will be &= ~bitMask */
     unsigned int bitMask;
 
-    /* Simple flag -- This handles the case fo 'TOKEN_STRING' in combo with 'TOKEN_SET'
+    /* Simple flag -- This handles the case of 'TOKEN_STRING' in combo with 'TOKEN_SET'
      * In that case, if this is set to '1' then free() will be called on value 
      * before it is overwritten to avoid a memory leak */
     bool freeFlag;
@@ -100,13 +100,13 @@ typedef struct TokenIdent {
 } TokenIdent;
 
 /*
- * Functions for handling allocationg of a TokenParser
+ * Functions for handling allocations of a TokenParser
  */
 TokenParser *tokenParserNew();
 void         tokenParserFree(TokenParser *parser);
 
 /*
- * Some bsic functions for creating MemoryBlocks
+ * Some basic functions for creating MemoryBlocks
  */
 MemoryBlock *memoryBlockNew();
 void memoryBlockFree(MemoryBlock *block);
@@ -145,7 +145,7 @@ void parseTokens  (TokenParser *parser, TokenIdent *identifiers, ...);
 #define TOKEN_IS_TRUE(json, token)   ((toupper(json[token.start])) == 'T')
 #define TOKEN_IS_FALSE(json, token)  ((toupper(json[token.start])) == 'F')
 
-/* These next macros take a token and read it in as a specefic type
+/* These next macros take a token and read it in as a specific type
  * of JSON object, either a string, number of boolean */
 #define READ_TOKEN_AS_STRING(string, json, token)     \
     do {                                              \
@@ -170,7 +170,7 @@ void parseTokens  (TokenParser *parser, TokenIdent *identifiers, ...);
     static void name (TokenParser *parser, TokenIdent *idents, va_list args)
 
 /*
- * This macro is a quick way to create token_ident entrys which simply set
+ * This macro is a quick way to create token_ident entries which simply set
  * a variable in a pointer to a struct that has the same name as it's key
  * (This is the most common use case)
  */

--- a/libreddit/user.c
+++ b/libreddit/user.c
@@ -10,7 +10,7 @@
 #include "token.h"
 
 /*
- * Allocate and reture a new 'RedditUser' struct'
+ * Allocate and return a new 'RedditUser' struct'
  *
  * A 'RedditUser' represents any and all users
  */
@@ -129,7 +129,7 @@ DEF_TOKEN_CALLBACK(handleCookie)
 /*
  * Takes a RedditUserLogged and returns a RedditErrno
  *
- * Logs in the user storred in the RedditUserLogged into Reddit
+ * Logs in the user stored in the RedditUserLogged into Reddit
  * Also if successful adds the 'reddit_session' cookie to the global state
  *
  */
@@ -178,7 +178,7 @@ EXPORT_SYMBOL RedditErrno redditUserLoggedLogin (RedditUserLogged *log, char *na
 
 /*
  * This callback handles a 'data' parameter and checks for a 't2', which
- * coresponds to a RedditUser JSON object.
+ * corresponds to a RedditUser JSON object.
  */
 DEF_TOKEN_CALLBACK(userUpdateHelper)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -735,10 +735,7 @@ int main(int argc, char *argv[])
 
     if (argc == 4) {
         user = redditUserLoggedNew();
-        /* If you want to try logging in as your user
-         * Replace 'username' and 'password' with the approiate fields */
         redditUserLoggedLogin(user, argv[2], argv[3]);
-
     }
     showSubreddit(subreddit);
 


### PR DESCRIPTION
What can I say, I'm a programmer, not an English major :P I just went through and checked the comments and README files with vim's built-in spell-checker.

There are a few spelling mistakes purposely left in to token.c and token.h to prevent merge conflicts since they are replaced by a separate pull-request.
