### PR TITLE
libreddit: Fix bug in Char parser and add support for \" Escape code

### DIFF
--- a/libreddit/token.c
+++ b/libreddit/token.c
@@ -443,6 +443,15 @@ static void parseChar (struct charParser *p)
                 p->cur+=4;
             }
             break;
+
+        case '\"':
+            if (p->wide)
+                ((wchar_t*)(p->new_text))[p->offset] = L'\"';
+            else
+                ((char*)(p->new_text))[p->offset] = '\"';
+            p->offset++;
+            break;
+
         }
         break;
     default:


### PR DESCRIPTION
There are two patches here. The first fixes an error I made in my new parser code (Sorry). I was missing a break statement, so the case for a newline was dropping into the next for unicode characters (And it ended up chopping off some characters). That's an easy fix, just add the break statement.

The second patch just adds support for the \" Escape Code for quotes. This is fairly straightforward, no real difference from the \n parsing code, except it inserts a quote character instead of a new line. (Eventually the code could be consolidated into some type of array of values to check and replacements for them, but with so few cases right now that may just over-do it).
