### PR TITLE
libreddit: creddit: Implement the 'morechildren' API call

### DIFF
--- a/include/reddit.h
+++ b/include/reddit.h
@@ -214,9 +214,10 @@ typedef struct RedditComment {
     struct RedditComment **replies;
     struct RedditComment *parent;
 
-    char *id;
+    char *id; /* Doesn't include 't1_' */
     char *author;
     char *parentId;
+    char *linkId;
 
     /* See 'RedditLink' for explanation of different strings */
     char *body;

--- a/libreddit/token.c
+++ b/libreddit/token.c
@@ -140,7 +140,7 @@ char *trueFalseString(char *string, bool tf)
         strcpy(string, "true");
     else
         strcpy(string, "false");
- 
+
     return string;
 }
 

--- a/libreddit/token.h
+++ b/libreddit/token.h
@@ -89,7 +89,7 @@ typedef struct TokenIdent {
     unsigned int bitMask;
 
     /* Simple flag -- This handles the case of 'TOKEN_STRING' in combo with 'TOKEN_SET'
-     * In that case, if this is set to '1' then free() will be called on value 
+     * In that case, if this is set to '1' then free() will be called on value
      * before it is overwritten to avoid a memory leak */
     bool freeFlag;
 


### PR DESCRIPTION
The 'morechildren' API call is used by reddit to gather hidden replies
to a comment. Replies are hidden simply when Reddit's algorithms decide
it's not worth displaying by default, and the libreddit API function
'redditGetCommentChildren'.

This patch also implements the use of the morechildren call into
cReddit's comment displaying screen. You can now see the number of
hidden replies to a comment, and pressing 'm' while a comment with
hidden replies is selected will trigger the morechildren call and add
the comments to the displayed list. (Currently, this is done by
rerendering the entire list. In the future it could probably be done a
bit more 'elegantly').

As far as testing goes, I tested it on a fairly large AMA (Which had comments that were reaching 100 hidden replies) and it worked without any noticeable problems or memory leaks. I would however recommend your own testing as well, seeing as this is a fairly complicated implementation.
