### PR TITLE
libreddit: Fix off-by-one error in morechildren call

### DIFF
--- a/libreddit/comment.c
+++ b/libreddit/comment.c
@@ -451,7 +451,7 @@ EXPORT_SYMBOL RedditErrno redditGetCommentChildren (RedditCommentList *list, Red
         parent->totalReplyCount -= children;
 
     endCount = parent->directChildrenCount - children;
-    for (i = parent->directChildrenCount; i >= endCount; i--)
+    for (i = parent->directChildrenCount - 1; i >= endCount; i--)
         free(parent->directChildrenIds[i]);
 
     parent->directChildrenCount = endCount;


### PR DESCRIPTION
This patch fixes an off-by-one error in the morechildren call. The error
itself was caused by not subtracting one from the number telling us the
size of an array. The result is that the program tries to call free on a
location past the end of the array, which may end-up causing a
seg-fault.
