### PR TITLE
creddit: libreddit: Project-wide debug option

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -1,0 +1,26 @@
+#ifndef _DEBUG_H_
+#define _DEBUG_H_
+
+/*
+ * If you compile with -DREDDIT_DEBUG, then debugging will be turned-on program-wide
+ *
+ * DEBUG_FILE is a module-specefic define macro that is set per-module
+ *   representing the FILE* to send debug information to (Ex. libreddit sets it
+ *   differently then creddit does)
+ * DEBUG_MODULE is a module-specefic defined macro that expands to a string
+ *   with that modules name
+ * DEBUG_PRINT is a macro that expands into a wide-character print to this file
+ */
+#ifdef REDDIT_DEBUG
+# define DEBUG_PRINT(...) \
+    do { \
+        fwprintf(DEBUG_FILE, L"%s: ", DEBUG_MODULE); \
+        fwprintf(DEBUG_FILE, __VA_ARGS__); \
+        fflush(DEBUG_FILE); \
+    } while (0)
+#else
+# define DEBUG_PRINT(...) do { ; } while (0)
+#endif
+
+
+#endif

--- a/include/reddit.h
+++ b/include/reddit.h
@@ -4,6 +4,9 @@
 #include <ctype.h>
 #include <stdbool.h>
 #include <wchar.h>
+#ifdef REDDIT_DEBUG
+# include <stdio.h>
+#endif
 
 /*
  * This enum represents all possible errors from libreddit. Every function that
@@ -345,5 +348,9 @@ extern wchar_t *redditParseEscCodesWide (const char *text, int len);
  * end of a program, respectively. */
 extern void redditGlobalInit();
 extern void redditGlobalCleanup();
+
+#ifdef REDDIT_DEBUG
+extern void redditSetDebugFile(FILE *file);
+#endif
 
 #endif

--- a/libreddit/global.c
+++ b/libreddit/global.c
@@ -51,19 +51,20 @@ void *rrealloc(void *old, size_t bytes)
 EXPORT_SYMBOL void redditGlobalInit()
 {
     curl_global_init(CURL_GLOBAL_ALL);
-#ifdef REDDIT_DEBUG
-    /* This starts debugging, using 'DEBUG_FILE' for the location to send messages to */
-    debugFile = fopen(DEBUG_FILE, "w");
-#endif
+    DEBUG_PRINT(L"libreddit Loaded\n");
 }
 
 EXPORT_SYMBOL void redditGlobalCleanup()
 {
     curl_global_cleanup();
-#ifdef REDDIT_DEBUG
-    /* Close the debugFile when we're called to close libreddit */
-    fclose(debugFile);
-#endif
+    DEBUG_PRINT(L"libreddit Closed\n");
 }
+
+#ifdef REDDIT_DEBUG
+EXPORT_SYMBOL void redditSetDebugFile(FILE *file)
+{
+    debugFile = file;
+}
+#endif
 
 #endif

--- a/libreddit/global.h
+++ b/libreddit/global.h
@@ -7,6 +7,14 @@
 #include "state.h"
 #include "token.h"
 
+#ifdef REDDIT_DEBUG
+extern FILE* debugFile;
+# define DEBUG_MODULE "libreddit"
+# define DEBUG_FILE   debugFile
+#endif
+
+#include "debug.h"
+
 /*
  * Current version of libreddit
  */
@@ -42,23 +50,6 @@
  *
  */
 extern RedditState *currentRedditState;
-
-/*
- * This adds debug macros and a debug FILE* pointer in the event that debugging is turned on
- * If you compile with -DREDDIT_DEBUG, then debugging will be used
- *
- * The 'debugFile' FILE* is the destination of all the debug messages.
- * DEBUG_FILE is the actual filename of where to send files to
- * DEBUG_PRINT is a macro that expands into a wide-character print to this file
- */
-#ifdef REDDIT_DEBUG
-  extern FILE *debugFile;
-# define DEBUG_FILE "/tmp/reddit_error.log"
-# define DEBUG_PRINT(...) fwprintf(debugFile, __VA_ARGS__)
-#else
-# define DEBUG_PRINT(...) do { ; } while (0)
-#endif
-
 
 void *rmalloc (size_t bytes);
 void *rrealloc (void *old, size_t bytes);

--- a/libreddit/token.c
+++ b/libreddit/token.c
@@ -319,6 +319,10 @@ TokenParserResult redditvRunParser(char *url, char *post, TokenIdent *idents, va
     jsmnerr_t jsmnResult;
     char fullUseragent[1024];
 
+    DEBUG_PRINT(L"Grabbing %s\n", url);
+    if (post)
+        DEBUG_PRINT(L"Post: %s\n", post);
+
     /* Set default response */
     TokenParserResult result = TOKEN_PARSER_SUCCESS;
 

--- a/src/global.c
+++ b/src/global.c
@@ -1,0 +1,6 @@
+
+#include <stdio.h>
+
+#include "global.h"
+
+FILE *debugFile;

--- a/src/global.h
+++ b/src/global.h
@@ -1,0 +1,26 @@
+#ifndef _SRC_GLOBAL_H_
+#define _SRC_GLOBAL_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef REDDIT_DEBUG
+  extern FILE *debugFile;
+# define DEBUG_START(file, filename) \
+    do { \
+        file = fopen(filename, "w"); \
+        redditSetDebugFile(file); \
+    } while (0)
+
+# define DEBUG_END(file) fclose(file)
+#else
+# define DEBUG_START(file, filename) do { ; } while (0)
+# define DEBUG_END(file) do { ; } while (0)
+#endif
+
+#define DEBUG_FILE     debugFile
+#define DEBUG_MODULE   "creddit"
+#define DEBUG_FILENAME "/tmp/reddit_errors.log"
+#include "debug.h"
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,9 @@
 #include <form.h>
 #include <locale.h>
 
+#include "global.h"
+
+
 #define SIZEOFELEM(x)  (sizeof(x) / sizeof(x[0]))
 
 typedef struct {
@@ -614,6 +617,7 @@ void linkScreenToggleHelp(LinkScreen *screen)
 void showSubreddit(const char *subreddit)
 {
     LinkScreen *screen;
+    DEBUG_PRINT(L"Loading Subreddit %s\n", subreddit);
     screen = linkScreenNew();
 
     screen->list = redditLinkListNew();
@@ -716,6 +720,8 @@ int main(int argc, char *argv[])
     RedditUserLogged *user = NULL;
     char *subreddit = NULL;
 
+    DEBUG_START(DEBUG_FILE, DEBUG_FILENAME);
+
     if (argc > 1) {
         subreddit = argv[1];
         /* Display a simple help screen */
@@ -753,6 +759,8 @@ int main(int argc, char *argv[])
     init_pair(1, -1, -1);
     init_pair(2, COLOR_BLACK, COLOR_WHITE);
 
+    DEBUG_PRINT(L"Starting...\n");
+
     /* Start libreddit */
     redditGlobalInit();
 
@@ -772,6 +780,8 @@ int main(int argc, char *argv[])
     redditStateFree(globalState);
     redditGlobalCleanup();
     endwin();
+
+    DEBUG_END(DEBUG_FILE);
     return 0;
 }
 


### PR DESCRIPTION
This patch expands the debug system to be a project-wide debug setup
instead of internal to each module. The basic idea is that
./include/debug.h is included by every module in every file and has
basic macros for DEBUG_PRINT. Each module takes the liberty of setting a
module name for itself for the debug log, as well as the FILE\* to write
to. The actual used FILE\* can be found in ./src/global.c, all the other
FILE\* for the debug file in other modules gets set to the contents of
that one when the program starts and the log file is opened. (You could set
the different modules to write output to different files, but that's not the default)

This really should have been what was done before, as the original debug
system was limited to libreddit and would have required a separate similar
system for creddit. This change allows for each module to use the same
unified debug setup.
