### PR TITLE
creddit: align index on LinkScreen to at least 2 digits

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -426,7 +426,7 @@ void linkScreenRenderLine (LinkScreen *screen, int line, int width)
 
     screen->screenLines[line] = realloc(screen->screenLines[line], (width + 1) * sizeof(wchar_t));
 
-    swprintf(screen->screenLines[line], width + 1, L"%d. [%4d] %20s - ", line + 1, screen->list->links[line]->score, screen->list->links[line]->author);
+    swprintf(screen->screenLines[line], width + 1, L"%2d. [%4d] %20s - ", line + 1, screen->list->links[line]->score, screen->list->links[line]->author);
 
     offset = wcslen(screen->screenLines[line]);
     title = wcslen(screen->list->links[line]->wtitleEsc);


### PR DESCRIPTION
Found this program yesterday, really cool! This is just a really minor issue I had, which motivated me to grok the code a bit. The rationale is that you will seldom have LinkScreens with less than 10 items, and before this change, the first nine items would have a weird offset in the UI compared to the rest of the items. This will still happen when displaying more than 100, and again when displaying more than 1000 items though (etc for every 10^n), but having it set to %3d seems a bit wasteful.
