### PR TITLE
creddit: Remove anonymous structs/unions from optOption

### DIFF
--- a/src/opt.h
+++ b/src/opt.h
@@ -83,14 +83,8 @@ struct optOption {
     char helpText[OPT_HELP_MAX + 1];
 
     unsigned int isSet :1;
-    union {
-        struct {
-            int ivalue;
-        };
-        struct {
-            char svalue[OPT_STRLEN + 1];
-        };
-    };
+    int ivalue;
+    char svalue[OPT_STRLEN + 1];
 };
 
 /* These macros are useful for easily creating an array entry for an option. It


### PR DESCRIPTION
Fix for #53. All that's going on here is removing the anonymous structs and unions so that GCC 4.2 can compile it. This should allow MacOSX to compile cReddit cleanly.
