### PR TITLE
Fixed wchar initialization to correct size

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,7 @@ typedef struct {
 
 RedditState *globalState;
 
-wchar_t *linkScreenHelp[19] = {
+wchar_t *linkScreenHelp[21] = {
     L"Keypresses:",
     L"Link Screen:",
     L"- k / UP -- Move up one link in the list",
@@ -233,7 +233,7 @@ void commentScreenDown(CommentScreen *screen)
     }
 }
 
-void commentScreenLevelDown(CommentScreen *screen) 
+void commentScreenLevelDown(CommentScreen *screen)
 {
     int newPosition = screen->selected;
     int indentCount = screen->lines[screen->selected]->indentCount;


### PR DESCRIPTION
The wide character initialization for the help screen was set to 19 but the
list actually contained 21 elements. This produced a compiler warning and
this commit removes that warning.

Signed-off-by: Adam Brenner <aebrenne@uci.edu>