### PR TITLE
Fix building against ncursesw on Linux

### DIFF
--- a/src/creddit.mk
+++ b/src/creddit.mk
@@ -5,6 +5,7 @@ ifdef F_MACOSX
 	CREDDIT_LDFLAGS+=-lncurses
 else
 	CREDDIT_LDFLAGS+=-lncursesw
+	CREDDIT_CFLAGS+=-DCREDDIT_USE_NCURSESW
 endif
 
 ifdef STATIC

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,11 @@
 #include <string.h>
 #include <stdbool.h>
 #include "reddit.h"
+#if defined(CREDDIT_USE_NCURSESW)
+#include <ncursesw/curses.h>
+#else
 #include <ncurses.h>
+#endif
 #include <form.h>
 #include <locale.h>
 


### PR DESCRIPTION
On Debian Linux, the build failed without this patch.